### PR TITLE
Travis build from develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 language: java
 jdk: oraclejdk8
 sudo: false
-script: mvn clean verify
-deploy:
-  provider: script
-  script: mvn clean deploy
-  on:
-    branch: release
+script: mvn clean deploy


### PR DESCRIPTION
Following the same pattern as bridge-base and BridgeJavaSDK, we want to build and publish from develop branch instead of having a 2-branch release process.
